### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/cnn/train_imagenet.py
+++ b/cnn/train_imagenet.py
@@ -18,12 +18,6 @@ import torch.backends.cudnn as cudnn
 from torch.autograd import Variable
 from model import NetworkImageNet as Network
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
-
-
 parser = argparse.ArgumentParser("imagenet")
 parser.add_argument('--data', type=str, default='../data/imagenet/', help='location of the data corpus')
 parser.add_argument('--batch_size', type=int, default=128, help='batch size')
@@ -146,7 +140,7 @@ def main():
   scheduler = torch.optim.lr_scheduler.StepLR(optimizer, args.decay_period, gamma=args.gamma)
 
   best_acc_top1 = 0
-  for epoch in xrange(args.epochs):
+  for epoch in range(args.epochs):
     scheduler.step()
     logging.info('epoch %d lr %e', epoch, scheduler.get_lr()[0])
     model.drop_path_prob = args.drop_path_prob * epoch / args.epochs
@@ -233,4 +227,3 @@ def infer(valid_queue, model, criterion):
 
 if __name__ == '__main__':
   main() 
-

--- a/cnn/train_imagenet.py
+++ b/cnn/train_imagenet.py
@@ -18,6 +18,11 @@ import torch.backends.cudnn as cudnn
 from torch.autograd import Variable
 from model import NetworkImageNet as Network
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 parser = argparse.ArgumentParser("imagenet")
 parser.add_argument('--data', type=str, default='../data/imagenet/', help='location of the data corpus')

--- a/cnn/train_imagenet.py
+++ b/cnn/train_imagenet.py
@@ -18,6 +18,7 @@ import torch.backends.cudnn as cudnn
 from torch.autograd import Variable
 from model import NetworkImageNet as Network
 
+
 parser = argparse.ArgumentParser("imagenet")
 parser.add_argument('--data', type=str, default='../data/imagenet/', help='location of the data corpus')
 parser.add_argument('--batch_size', type=int, default=128, help='batch size')


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  This PR avoids __NameError__ being raised in Python 3. https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists