### PR TITLE
Making the code dataset agnostic

### DIFF
--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -31,13 +31,13 @@ def load_dataset(args, train=True):
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
-        # TODO: add transforms?
+        train_transform, valid_transform = utils._data_transforms_mnist(args)
         data = dset.MNIST(root=args.data, train=train, download=True, transform=None)
         output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
-        # TODO: add transforms?
+        train_transform, valid_transform = utils._data_transforms_mnist(args)
         data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=None)
         output_dim = 10
         is_regression = False

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -1,0 +1,33 @@
+## Datasets Module
+
+import utils
+import torchvision.datasets as dset
+
+VALID_DSET_NAMES = {
+    'CIFAR': ['cifar', 'cifar10', 'cifar-10'],
+    'MNIST': ['mnist'],
+    'FashionMNIST': ['fashionmnist', 'fashion-mnist', 'mnistfashion']
+}
+
+def load_dataset(args):
+    """ function to load datasets (e.g. CIFAR10, MNIST, FashionMNIST, Graphene) """
+    dset_name = args.dataset.lower().strip()
+
+    if dset_name in VALID_DSET_NAMES['CIFAR']:
+        train_transform, valid_transform = utils._data_transforms_cifar10(args)
+        train_data = dset.CIFAR10(root=args.data, train=True, download=True, transform=train_transform)
+
+    elif dset_name in VALID_DSET_NAMES['MNIST']:
+        # TODO: add transforms
+        train_data = dset.MNIST(root=args.data, train=True, download=True, transform=None)
+
+    elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
+        # TODO: add transforms
+        train_data = dset.FashionMNIST(root=args.data, train=True, download=True, transform=None)
+
+    else:
+        exc_str = 'Unable to match provided dataset name: {}'.format(dset_name)
+        exc_str += '\nValid names are case-insensitive elements of: {}'.format(VALID_DSET_NAMES)
+        raise RuntimeError(exc_str)
+
+    return train_data

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -27,19 +27,19 @@ def load_dataset(args, train=True):
         # from the original DARTS code
         train_transform, valid_transform = utils._data_transforms_cifar10(args)
         data = dset.CIFAR10(root=args.data, train=train, download=True, transform=train_transform)
-        output_dim = len(data.classes)
+        output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
         # TODO: add transforms?
         data = dset.MNIST(root=args.data, train=train, download=True, transform=None)
-        output_dim = len(data.classes)
+        output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
         # TODO: add transforms?
         data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=None)
-        output_dim = len(data.classes)
+        output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['GrapheneKirigami']:

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -11,23 +11,41 @@ VALID_DSET_NAMES = {
 }
 
 def load_dataset(args, train=True):
-    """ function to load datasets (e.g. CIFAR10, MNIST, FashionMNIST, Graphene) """
+    """ function to load datasets (e.g. CIFAR10, MNIST, FashionMNIST, Graphene)
+
+    input:
+        args - result of ArgumentParser.parse() containing a `dataset` property
+
+    output:
+        data - a torch Dataset
+        output_dim - an integer representing necessary output dimension for a model
+        is_regression - boolean indicator for regression problems
+    """
     dset_name = args.dataset.lower().strip()
 
     if dset_name in VALID_DSET_NAMES['CIFAR']:
+        # from the original DARTS code
         train_transform, valid_transform = utils._data_transforms_cifar10(args)
         data = dset.CIFAR10(root=args.data, train=train, download=True, transform=train_transform)
+        output_dim = len(data.classes)
+        is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
-        # TODO: add transforms
+        # TODO: add transforms?
         data = dset.MNIST(root=args.data, train=train, download=True, transform=None)
+        output_dim = len(data.classes)
+        is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
-        # TODO: add transforms
+        # TODO: add transforms?
         data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=None)
+        output_dim = len(data.classes)
+        is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['GrapheneKirigami']:
         # TODO: implement loading graphene
+        # output_dim =
+        # is_regression = True
         raise NotImplementedError()
 
     else:
@@ -35,4 +53,4 @@ def load_dataset(args, train=True):
         exc_str += '\nValid names are case-insensitive elements of: {}'.format(VALID_DSET_NAMES)
         raise RuntimeError(exc_str)
 
-    return data
+    return data, output_dim, is_regression

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -6,28 +6,33 @@ import torchvision.datasets as dset
 VALID_DSET_NAMES = {
     'CIFAR': ['cifar', 'cifar10', 'cifar-10'],
     'MNIST': ['mnist'],
-    'FashionMNIST': ['fashionmnist', 'fashion-mnist', 'mnistfashion']
+    'FashionMNIST': ['fashionmnist', 'fashion-mnist', 'mnistfashion'],
+    'GrapheneKirigami': ['graphene', 'graphenekirigami', 'graphene-kirigami', 'kirigami']
 }
 
-def load_dataset(args):
+def load_dataset(args, train=True):
     """ function to load datasets (e.g. CIFAR10, MNIST, FashionMNIST, Graphene) """
     dset_name = args.dataset.lower().strip()
 
     if dset_name in VALID_DSET_NAMES['CIFAR']:
         train_transform, valid_transform = utils._data_transforms_cifar10(args)
-        train_data = dset.CIFAR10(root=args.data, train=True, download=True, transform=train_transform)
+        data = dset.CIFAR10(root=args.data, train=train, download=True, transform=train_transform)
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
         # TODO: add transforms
-        train_data = dset.MNIST(root=args.data, train=True, download=True, transform=None)
+        data = dset.MNIST(root=args.data, train=train, download=True, transform=None)
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
         # TODO: add transforms
-        train_data = dset.FashionMNIST(root=args.data, train=True, download=True, transform=None)
+        data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=None)
+
+    elif dset_name in VALID_DSET_NAMES['GrapheneKirigami']:
+        # TODO: implement loading graphene
+        raise NotImplementedError()
 
     else:
         exc_str = 'Unable to match provided dataset name: {}'.format(dset_name)
         exc_str += '\nValid names are case-insensitive elements of: {}'.format(VALID_DSET_NAMES)
         raise RuntimeError(exc_str)
 
-    return train_data
+    return data

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -26,19 +26,22 @@ def load_dataset(args, train=True):
     if dset_name in VALID_DSET_NAMES['CIFAR']:
         # from the original DARTS code
         train_transform, valid_transform = utils._data_transforms_cifar10(args)
-        data = dset.CIFAR10(root=args.data, train=train, download=True, transform=train_transform)
+        tr = train_transform if train else valid_transform
+        data = dset.CIFAR10(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
         train_transform, valid_transform = utils._data_transforms_mnist(args)
-        data = dset.MNIST(root=args.data, train=train, download=True, transform=None)
+        tr = train_transform if train else valid_transform
+        data = dset.MNIST(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
         train_transform, valid_transform = utils._data_transforms_mnist(args)
-        data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=None)
+        tr = train_transform if train else valid_transform
+        data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
         is_regression = False
 

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -29,6 +29,7 @@ def load_dataset(args, train=True):
         tr = train_transform if train else valid_transform
         data = dset.CIFAR10(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
+        in_channels = 3
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['MNIST']:
@@ -36,6 +37,7 @@ def load_dataset(args, train=True):
         tr = train_transform if train else valid_transform
         data = dset.MNIST(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
+        in_channels = 1
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['FashionMNIST']:
@@ -43,6 +45,7 @@ def load_dataset(args, train=True):
         tr = train_transform if train else valid_transform
         data = dset.FashionMNIST(root=args.data, train=train, download=True, transform=tr)
         output_dim = 10
+        in_channels = 1
         is_regression = False
 
     elif dset_name in VALID_DSET_NAMES['GrapheneKirigami']:
@@ -56,4 +59,4 @@ def load_dataset(args, train=True):
         exc_str += '\nValid names are case-insensitive elements of: {}'.format(VALID_DSET_NAMES)
         raise RuntimeError(exc_str)
 
-    return data, output_dim, is_regression
+    return data, output_dim, in_channels, is_regression

--- a/cnn/model.py
+++ b/cnn/model.py
@@ -16,7 +16,7 @@ class Cell(nn.Module):
     else:
       self.preprocess0 = ReLUConvBN(C_prev_prev, C, 1, 1, 0)
     self.preprocess1 = ReLUConvBN(C_prev, C, 1, 1, 0)
-    
+
     if reduction:
       op_names, indices = zip(*genotype.reduce)
       concat = genotype.reduce_concat
@@ -110,18 +110,19 @@ class AuxiliaryHeadImageNet(nn.Module):
 
 class NetworkCIFAR(nn.Module):
 
-  def __init__(self, C, num_classes, layers, auxiliary, genotype):
+  def __init__(self, C, num_classes, layers, auxiliary, genotype, num_channels=3):
     super(NetworkCIFAR, self).__init__()
     self._layers = layers
     self._auxiliary = auxiliary
+    self._num_channels = num_channels
 
     stem_multiplier = 3
     C_curr = stem_multiplier*C
     self.stem = nn.Sequential(
-      nn.Conv2d(3, C_curr, 3, padding=1, bias=False),
+      nn.Conv2d(self._num_channels, C_curr, 3, padding=1, bias=False),
       nn.BatchNorm2d(C_curr)
     )
-    
+
     C_prev_prev, C_prev, C_curr = C_curr, C_curr, C
     self.cells = nn.ModuleList()
     reduction_prev = False
@@ -158,13 +159,14 @@ class NetworkCIFAR(nn.Module):
 
 class NetworkImageNet(nn.Module):
 
-  def __init__(self, C, num_classes, layers, auxiliary, genotype):
+  def __init__(self, C, num_classes, layers, auxiliary, genotype, num_channels=3):
     super(NetworkImageNet, self).__init__()
     self._layers = layers
     self._auxiliary = auxiliary
+    self._num_channels = num_channels
 
     self.stem0 = nn.Sequential(
-      nn.Conv2d(3, C // 2, kernel_size=3, stride=2, padding=1, bias=False),
+      nn.Conv2d(self._num_channels, C // 2, kernel_size=3, stride=2, padding=1, bias=False),
       nn.BatchNorm2d(C // 2),
       nn.ReLU(inplace=True),
       nn.Conv2d(C // 2, C, 3, stride=2, padding=1, bias=False),
@@ -211,4 +213,3 @@ class NetworkImageNet(nn.Module):
     out = self.global_pooling(s1)
     logits = self.classifier(out.view(out.size(0), -1))
     return logits, logits_aux
-

--- a/cnn/model_search.py
+++ b/cnn/model_search.py
@@ -60,7 +60,7 @@ class Cell(nn.Module):
 
 class Network(nn.Module):
 
-  def __init__(self, C, num_classes, layers, criterion, steps=4, multiplier=4, stem_multiplier=3):
+  def __init__(self, C, num_classes, num_channels, layers, criterion, steps=4, multiplier=4, stem_multiplier=3):
     super(Network, self).__init__()
     self._C = C
     self._num_classes = num_classes
@@ -68,13 +68,14 @@ class Network(nn.Module):
     self._criterion = criterion
     self._steps = steps
     self._multiplier = multiplier
+    self._num_channels = num_channels
 
     C_curr = stem_multiplier*C
     self.stem = nn.Sequential(
-      nn.Conv2d(3, C_curr, 3, padding=1, bias=False),
+      nn.Conv2d(self._num_channels, C_curr, 3, padding=1, bias=False),
       nn.BatchNorm2d(C_curr)
     )
- 
+
     C_prev_prev, C_prev, C_curr = C_curr, C_curr, C
     self.cells = nn.ModuleList()
     reduction_prev = False
@@ -114,7 +115,7 @@ class Network(nn.Module):
 
   def _loss(self, input, target):
     logits = self(input)
-    return self._criterion(logits, target) 
+    return self._criterion(logits, target)
 
   def _initialize_alphas(self):
     k = sum(1 for i in range(self._steps) for n in range(2+i))
@@ -160,4 +161,3 @@ class Network(nn.Module):
       reduce=gene_reduce, reduce_concat=concat
     )
     return genotype
-

--- a/cnn/model_search.py
+++ b/cnn/model_search.py
@@ -72,6 +72,7 @@ class Network(nn.Module):
 
     C_curr = stem_multiplier*C
     self.stem = nn.Sequential(
+      # in_channels, out_channels, kernel_size
       nn.Conv2d(self._num_channels, C_curr, 3, padding=1, bias=False),
       nn.BatchNorm2d(C_curr)
     )
@@ -96,7 +97,7 @@ class Network(nn.Module):
     self._initialize_alphas()
 
   def new(self):
-    model_new = Network(self._C, self._num_classes, self._layers, self._criterion).cuda()
+    model_new = Network(self._C, self._num_classes, self._layers, self._criterion, num_channels=self._num_channels).cuda()
     for x, y in zip(model_new.arch_parameters(), self.arch_parameters()):
         x.data.copy_(y.data)
     return model_new

--- a/cnn/model_search.py
+++ b/cnn/model_search.py
@@ -60,7 +60,7 @@ class Cell(nn.Module):
 
 class Network(nn.Module):
 
-  def __init__(self, C, num_classes, num_channels, layers, criterion, steps=4, multiplier=4, stem_multiplier=3):
+  def __init__(self, C, num_classes, layers, criterion, num_channels=3, steps=4, multiplier=4, stem_multiplier=3):
     super(Network, self).__init__()
     self._C = C
     self._num_classes = num_classes

--- a/cnn/test.py
+++ b/cnn/test.py
@@ -16,7 +16,8 @@ from torch.autograd import Variable
 from model import NetworkCIFAR as Network
 
 
-parser = argparse.ArgumentParser("cifar")
+parser = argparse.ArgumentParser("darts")
+parser.add_argument('--dataset', type=str, default='cifar', help='name of the dataset to use (e.g. cifar, mnist, graphene)')
 parser.add_argument('--data', type=str, default='../data', help='location of the data corpus')
 parser.add_argument('--batch_size', type=int, default=96, help='batch size')
 parser.add_argument('--report_freq', type=float, default=50, help='report frequency')
@@ -54,17 +55,18 @@ def main():
   logging.info("args = %s", args)
 
   genotype = eval("genotypes.%s" % args.arch)
-  model = Network(args.init_channels, CIFAR_CLASSES, args.layers, args.auxiliary, genotype)
+
+  valid_data, OUTPUT_DIM, IN_CHANNELS, is_regression = load_dataset(args, train=False)
+
+  model = Network(args.init_channels, OUTPUT_DIM, args.layers, args.auxiliary, genotype, num_channels=IN_CHANNELS)
   model = model.cuda()
+
   utils.load(model, args.model_path)
 
   logging.info("param size = %fMB", utils.count_parameters_in_MB(model))
 
-  criterion = nn.CrossEntropyLoss()
+  criterion = nn.CrossEntropyLoss() if not is_regression else nn.MSELoss()
   criterion = criterion.cuda()
-
-  _, test_transform = utils._data_transforms_cifar10(args)
-  test_data = dset.CIFAR10(root=args.data, train=False, download=True, transform=test_transform)
 
   test_queue = torch.utils.data.DataLoader(
       test_data, batch_size=args.batch_size, shuffle=False, pin_memory=True, num_workers=2)
@@ -100,5 +102,4 @@ def infer(test_queue, model, criterion):
 
 
 if __name__ == '__main__':
-  main() 
-
+  main()

--- a/cnn/test.py
+++ b/cnn/test.py
@@ -13,7 +13,9 @@ import torchvision.datasets as dset
 import torch.backends.cudnn as cudnn
 
 from torch.autograd import Variable
+# TODO: possibly use different network
 from model import NetworkCIFAR as Network
+from datasets import load_dataset
 
 
 parser = argparse.ArgumentParser("darts")

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -69,7 +69,7 @@ def main():
   logging.info('gpu device = %d' % args.gpu)
   logging.info("args = %s", args)
 
-  train_data, OUTPUT_DIM, is_regression = load_dataset(args, train=True)
+  train_data, OUTPUT_DIM, IN_CHANNELS, is_regression = load_dataset(args, train=True)
 
   num_train = len(train_data)
   indices = list(range(num_train))
@@ -89,7 +89,7 @@ def main():
   criterion = criterion.cuda()
 
   # TODO: test that passing a regression criterion here properly performs regression
-  model = Network(args.init_channels, OUTPUT_DIM, args.layers, criterion)
+  model = Network(args.init_channels, OUTPUT_DIM, IN_CHANNELS, args.layers, criterion)
   model = model.cuda()
   logging.info("param size = %fMB", utils.count_parameters_in_MB(model))
 

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -20,7 +20,6 @@ from datasets import load_dataset
 
 
 parser = argparse.ArgumentParser("darts")
-
 parser.add_argument('--dataset', type=str, default='cifar', help='name of the dataset to use (e.g. cifar, mnist, graphene)')
 parser.add_argument('--data', type=str, default='../data', help='location of the data corpus')
 parser.add_argument('--batch_size', type=int, default=64, help='batch size')

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -89,7 +89,7 @@ def main():
   criterion = criterion.cuda()
 
   # TODO: test that passing a regression criterion here properly performs regression
-  model = Network(args.init_channels, OUTPUT_DIM, IN_CHANNELS, args.layers, criterion)
+  model = Network(args.init_channels, OUTPUT_DIM, args.layers, criterion, num_channels=IN_CHANNELS)
   model = model.cuda()
   logging.info("param size = %fMB", utils.count_parameters_in_MB(model))
 

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -16,7 +16,7 @@ import torch.backends.cudnn as cudnn
 from torch.autograd import Variable
 from model_search import Network
 from architect import Architect
-from datasets import from_file
+from datasets import load_dataset
 
 
 parser = argparse.ArgumentParser("darts")
@@ -70,7 +70,7 @@ def main():
   logging.info('gpu device = %d' % args.gpu)
   logging.info("args = %s", args)
 
-  train_data, OUTPUT_DIM, is_regression = datasets.load_dataset(args, train=True)
+  train_data, OUTPUT_DIM, is_regression = load_dataset(args, train=True)
 
   num_train = len(train_data)
   indices = list(range(num_train))

--- a/cnn/utils.py
+++ b/cnn/utils.py
@@ -78,6 +78,24 @@ def _data_transforms_cifar10(args):
     ])
   return train_transform, valid_transform
 
+def _data_transforms_mnist(args):
+  MNIST_MEAN = [33.318421449829934]
+  MNIST_STD = [78.56748998339798]
+
+  train_transform = transforms.Compose([
+    transforms.RandomCrop(28, padding=4),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    transforms.Normalize(MNIST_MEAN, MNIST_STD),
+  ])
+  if args.cutout:
+    train_transform.transforms.append(Cutout(args.cutout_length))
+
+  valid_transform = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize(MNIST_MEAN, MNIST_STD),
+    ])
+  return train_transform, valid_transform
 
 def count_parameters_in_MB(model):
   return np.sum(np.prod(v.size()) for name, v in model.named_parameters() if "auxiliary" not in name)/1e6
@@ -118,4 +136,3 @@ def create_exp_dir(path, scripts_to_save=None):
     for script in scripts_to_save:
       dst_file = os.path.join(path, 'scripts', os.path.basename(script))
       shutil.copyfile(script, dst_file)
-


### PR DESCRIPTION
This PR adds a `datasets` module with a `load_dataset` function that loads datasets, preprocesses them, and returns various important parameters (e.g. num channels, output dimension) to perform training.

This PR also makes the `model_search.Network` and `model.NetworkCifar` objects agnostic to the number of input channels of the data (as far as I'm aware).